### PR TITLE
ftests: exclude cgroup v2 tests if cgroup v1

### DIFF
--- a/adaptived/configure.ac
+++ b/adaptived/configure.ac
@@ -92,6 +92,11 @@ AC_CONFIG_FILES([
 AC_CONFIG_FILES([dist/adaptived.spec:dist/adaptived.spec.in])
 
 dnl #
+dnl # if cgroup v1, exclude cgroup v2 tests
+dnl #
+AM_CONDITIONAL([CGV2], [test `grep ^cgroup2 /proc/mounts |awk '{print $1}'` = "cgroup2"])
+
+dnl #
 dnl # generate the configure and makefiles
 dnl #
 AC_OUTPUT

--- a/adaptived/tests/ftests/Makefile.am
+++ b/adaptived/tests/ftests/Makefile.am
@@ -184,15 +184,20 @@ check_PROGRAMS = \
 	test066 \
 	test067 \
 	test068 \
-	test069 \
-	sudo1000 \
-	sudo1001 \
-	sudo1002 \
-	sudo1003 \
-	sudo1004 \
-	sudo1005 \
-	sudo1006 \
-	sudo1007
+	test069
+
+if CGV2
+check_PROGRAMS += sudo1000
+check_PROGRAMS += sudo1001
+check_PROGRAMS += sudo1002
+check_PROGRAMS += sudo1003
+check_PROGRAMS += sudo1004
+check_PROGRAMS += sudo1005
+check_PROGRAMS += sudo1006
+check_PROGRAMS += sudo1007
+else
+$(warning WARNING: cgroup v2 is not enabled. Some tests excluded.)
+endif
 
 EXTRA_DIST_PYTHON_TESTS = \
 	001-cause-time_of_day.py \
@@ -296,7 +301,7 @@ EXTRA_DIST = \
 clean-local: clean-local-check
 .PHONY: clean-local-check
 clean-local-check:
-	-rm -f *.pyc
+	-rm -f *.pyc sudo*
 
 check-build:
 	${MAKE} ${AM_MAKEFLAGS} ${check_PROGRAMS}


### PR DESCRIPTION
Check if cgroup v2 is enabled and if not, exclude
cgroup v2 only tests.