### PR TITLE
ftests: check if fopen() calls fail

### DIFF
--- a/adaptived/tests/ftests/ftests.c
+++ b/adaptived/tests/ftests/ftests.c
@@ -58,6 +58,10 @@ void write_file(const char * const filename, const char * const contents)
 	FILE *f;
 
 	f = fopen(filename, "w");
+        if (!f) {
+                adaptived_err("write_file: cannot open %s\n", filename);
+                return;
+        }
 
 	if (strlen(contents))
 		fprintf(f, "%s", contents);
@@ -131,6 +135,10 @@ int verify_int_file(const char * const filename, int expected_value)
 	FILE *f;
 
 	f = fopen(filename, "r");
+        if (!f) {
+                adaptived_err("verify_int_file: cannot open %s\n", filename);
+                return -EINVAL;
+        }
 
 	bytes_read = fread(buf, 1, sizeof(buf), f);
 	if (bytes_read <= 0) {
@@ -161,6 +169,10 @@ int verify_ll_file(const char * const filename, long long expected_value)
 	FILE *f;
 
 	f = fopen(filename, "r");
+        if (!f) {
+                adaptived_err("verify_ll_file: cannot open %s\n", filename);
+                return -EINVAL;
+        }
 
 	bytes_read = fread(buf, 1, sizeof(buf), f);
 	if (bytes_read <= 0) {
@@ -190,6 +202,10 @@ int verify_char_file(const char * const filename, const char * const expected_co
 	FILE *f;
 
 	f = fopen(filename, "r");
+        if (!f) {
+                adaptived_err("verify_char_file: cannot open %s\n", filename);
+                return -EINVAL;
+        }
 
 	bytes_read = fread(buf, 1, sizeof(buf), f);
 	if (bytes_read <= 0) {


### PR DESCRIPTION
Check if fopen() call fails to avoid SIGSEGV if the file does not exist.