### PR TITLE
ftests: let systemd create the test slice

### DIFF
--- a/adaptived/include/adaptived-utils.h
+++ b/adaptived/include/adaptived-utils.h
@@ -263,6 +263,7 @@ int adaptived_farray_linear_regression(float * const array, int array_len, int i
 				    int interp_x, float * const interp_y);
 
 #define ADAPTIVED_CGROUP_FLAGS_VALIDATE 0x1
+#define ADAPTIVED_CGROUP_FLAGS_RUNTIME	0x2	/* systemctl --runtime: make changes only temporarily */
 
 /**
  * Write a long long value to a cgroup setting

--- a/adaptived/src/utils/sd_bus_utils.c
+++ b/adaptived/src/utils/sd_bus_utils.c
@@ -234,7 +234,7 @@ static int property_assignment(sd_bus_message *m, cgroupType t, const char *prop
 }
 
 static int set_property(const char *name, const char *property,
-			const struct adaptived_cgroup_value * const value)
+			const struct adaptived_cgroup_value * const value, bool arg_runtime)
 {
 	sd_bus_error error = SD_BUS_ERROR_NULL;
 	sd_bus_message *m = NULL;
@@ -242,7 +242,7 @@ static int set_property(const char *name, const char *property,
 	int r;
 	cgroupType t;
 
-	adaptived_dbg("set_property: name=%s, property=%s\n", name, property);
+	adaptived_dbg("set_property: name=%s, property=%s, arg_runtime=%d\n", name, property, arg_runtime);
 
 	r = sd_bus_default_system(&bus);
 	if (r < 0) {
@@ -264,7 +264,7 @@ static int set_property(const char *name, const char *property,
 		return t;
 	}
 
-	r = sd_bus_message_append(m, "sb", name, false);
+	r = sd_bus_message_append(m, "sb", name, arg_runtime);
 	if (r < 0) {
 		adaptived_err("set_property: sd_bus_message_append() failed, r=%d\n", r);
 		return r;
@@ -359,6 +359,7 @@ API int adaptived_sd_bus_set_ll(const char * const target, const char * const pr
 {
 	struct adaptived_cgroup_value val;
 	int ret = 0;
+	bool arg_runtime = false;
 
 	if (!target || !property)
 		return -EINVAL;
@@ -368,7 +369,10 @@ API int adaptived_sd_bus_set_ll(const char * const target, const char * const pr
 	val.type = ADAPTIVED_CGVAL_LONG_LONG;
 	val.value.ll_value = value;
 
-	ret = set_property(target, property, &val);
+	if (flags & ADAPTIVED_CGROUP_FLAGS_RUNTIME)
+		arg_runtime = true;
+
+	ret = set_property(target, property, &val, arg_runtime);
 	if (ret < 0)
 		return ret;
 
@@ -395,6 +399,7 @@ API int adaptived_sd_bus_set_str(const char * const target, const char * const p
 {
 	struct adaptived_cgroup_value val;
 	int ret = 0;
+	bool arg_runtime = false;
 
 	if (!target || !property || !value)
 		return -EINVAL;
@@ -404,7 +409,10 @@ API int adaptived_sd_bus_set_str(const char * const target, const char * const p
 	val.type = ADAPTIVED_CGVAL_STR;
 	val.value.str_value = (char *)value;
 
-	ret = set_property(target, property, &val);
+	if (flags & ADAPTIVED_CGROUP_FLAGS_RUNTIME)
+		arg_runtime = true;
+
+	ret = set_property(target, property, &val, arg_runtime);
 	if (ret < 0)
 		return ret;
 

--- a/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.c
+++ b/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.c
@@ -67,11 +67,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-	ret = start_slice(cgroup_slice_name, "cat");
-	if (ret) {
-		adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-		goto err;
-	}
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.json
+++ b/adaptived/tests/ftests/1000-sudo-effect-sd_bus_setting_set_int.json
@@ -17,7 +17,8 @@
 						"setting": "MemoryMax",
 						"value": 89997312,
 						"operator": "set",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.c
+++ b/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.c
@@ -67,11 +67,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-	ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.json
+++ b/adaptived/tests/ftests/1001-sudo-effect-sd_bus_setting_add_int.json
@@ -16,7 +16,8 @@
 						"target": "sudo1001.slice",
 						"setting": "MemoryMax",
 						"value": 89997312,
-						"operator": "set"
+						"operator": "set",
+						"runtime": true
 					}
 				},
 				{
@@ -26,7 +27,8 @@
 						"setting": "MemoryMax",
 						"value": 4096,
 						"operator": "add",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.c
+++ b/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.c
@@ -67,11 +67,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-        ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.json
+++ b/adaptived/tests/ftests/1002-sudo-effect-sd_bus_setting_sub_int.json
@@ -16,7 +16,8 @@
 						"target": "sudo1002.slice",
 						"setting": "MemoryMax",
 						"value": 89997312,
-						"operator": "set"
+						"operator": "set",
+						"runtime": true
 					}
 				},
 				{
@@ -26,7 +27,8 @@
 						"setting": "MemoryMax",
 						"value": 4096,
 						"operator": "subtract",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.c
+++ b/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.c
@@ -73,11 +73,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-        ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.json
+++ b/adaptived/tests/ftests/1003-sudo-effect-sd_bus_setting-CPUQuota.json
@@ -16,7 +16,8 @@
 						"target": "sudo1003.slice",
 						"setting": "CPUQuotaPeriodSec",
 						"value": "1s",
-						"operator": "set"
+						"operator": "set",
+						"runtime": true
 					}
 				},
 				{
@@ -25,7 +26,8 @@
 						"target": "sudo1003.slice",
 						"setting": "CPUQuota",
 						"value": "44%",
-						"operator": "set"
+						"operator": "set",
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.c
+++ b/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.c
@@ -68,11 +68,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-        ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.json
+++ b/adaptived/tests/ftests/1004-sudo-effect-sd_bus_setting_add_int_infinity.json
@@ -17,7 +17,8 @@
 						"setting": "MemoryMax",
 						"value": "infinity",
 						"operator": "set",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				},
 				{
@@ -27,7 +28,8 @@
 						"setting": "MemoryMax",
 						"value": 4096,
 						"operator": "add",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
+++ b/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
@@ -73,11 +73,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-        ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.json
+++ b/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.json
@@ -17,7 +17,8 @@
 						"setting": "MemoryMax",
 						"value": "infinity",
 						"operator": "set",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				},
 				{
@@ -27,7 +28,8 @@
 						"setting": "MemoryMax",
 						"value": 4096,
 						"operator": "subtract",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.json
+++ b/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.json
@@ -17,7 +17,8 @@
 						"setting": "MemoryMax",
 						"value": 89997312,
 						"operator": "set",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]

--- a/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.c
+++ b/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.c
@@ -68,11 +68,7 @@ int main(int argc, char *argv[])
 	ret = adaptived_set_attr(ctx, ADAPTIVED_ATTR_LOG_LEVEL, LOG_DEBUG);
 	if (ret)
 		goto err;
-	ret = start_slice(cgroup_slice_name, "cat");
-        if (ret) {
-                adaptived_err("Failed to create slice: %s, ret=%d\n", cgroup_slice_name, ret);
-                goto err;
-        }
+
 	ret = adaptived_loop(ctx, true);
 	if (ret != EXPECTED_RET)
 		goto err;

--- a/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.json
+++ b/adaptived/tests/ftests/1007-sudo-effect-sd_bus_setting_set_str.json
@@ -17,7 +17,8 @@
 						"setting": "DevicePolicy",
 						"value": "closed",
 						"operator": "set",
-						"validate": true
+						"validate": true,
+						"runtime": true
 					}
 				}
 			]


### PR DESCRIPTION
It is not necessary to create the test slice as systemd creates the slice if it does not exist. In addition, set the _runtime_ option in the sudo tests so that the settings are temporary (same as "systemctl --runtime").