### PR TITLE
adaptived: enhance json config file error handling

### DIFF
--- a/adaptived/src/parse.c
+++ b/adaptived/src/parse.c
@@ -624,6 +624,8 @@ static int parse_json(struct adaptived_ctx * const ctx, const char * const buf)
 
 	obj = json_tokener_parse_verbose(buf, &err);
 	if (!obj || err) {
+		if (err)
+			adaptived_err("%s: %s\n", __func__, json_tokener_error_desc(err));
 		ret = -EINVAL;
 		goto out;
 	}


### PR DESCRIPTION
Run the error enum returned by json_tokener_parse_verbose() through json_tokener_error_desc() for a string with a human readable description of the error.

If a comma is missing from a json config file, the following error will be displayed:
```
Error: parse_json: object value separator ',' expected
```
If the ending curly bracket is missing, the following error will be displayd:
```
Error: parse_json: unexpected end of data
```