### PR TITLE
adaptived: Warn on all errors

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -129,6 +129,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: false
+    - name: Fail on all warnings
+      run: |
+        CFLAGS=-Werror
+        export CFLAGS
     - name: Initialize the directory
       uses: ./.github/actions/setup-adaptived
     - name: Run functional tests
@@ -168,6 +172,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: false
+    - name: Fail on all warnings
+      run: |
+        CFLAGS=-Werror
+        export CFLAGS
     - name: Initialize the directory
       uses: ./.github/actions/setup-adaptived
     - name: Run functional tests

--- a/adaptived/src/Makefile.am
+++ b/adaptived/src/Makefile.am
@@ -48,14 +48,14 @@ SOURCES = \
 	utils/sched_utils.c
 
 adaptived_SOURCES = ${SOURCES}
-adaptived_CFLAGS = ${AM_CFLAGS} ${CFLAGS}  ${CODE_COVERAGE_CFLAGS}
+adaptived_CFLAGS = ${AM_CFLAGS} ${CFLAGS}  ${CODE_COVERAGE_CFLAGS} -Wall
 adaptived_LDFLAGS = ${AM_LDFLAGS} ${LDFLAGS} ${CODE_COVERAGE_LIBS} -ljson-c -lpthread -lsystemd
 sbin_PROGRAMS = adaptived
 
 libadaptived_la_SOURCES = ${SOURCES}
 libadaptived_la_LIBADD = ${CODE_COVERAGE_LIBS} -ljson-c -lpthread -lsystemd
 libadaptived_la_CFLAGS = ${AM_CFLAGS} ${CFLAGS} ${CODE_COVERAGE_CFLAGS} -fPIC \
-		      -fvisibility=hidden
+		      -fvisibility=hidden -Wall
 libadaptived_la_LDFLAGS = ${AM_LDFLAGS} ${CODE_COVERAGE_LDFLAGS} ${LDFLAGS} \
 		       -version-number ${VERSION_MAJOR}:${VERSION_MINOR}:${VERSION_MICRO}
 lib_LTLIBRARIES = libadaptived.la

--- a/adaptived/tests/ftests/Makefile.am
+++ b/adaptived/tests/ftests/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST_PYTHON_FILES = \
 	run.py \
 	utils.py
 
-AM_CFLAGS = ${CFLAGS}
+AM_CFLAGS = ${CFLAGS} -Wall
 AM_LDFLAGS = ${LDFLAGS} ${CODE_COVERAGE_LIBS}
 LDADD = -ljson-c -lpthread ${top_builddir}/src/libadaptived.la
 

--- a/adaptived/tests/gunit/Makefile.am
+++ b/adaptived/tests/gunit/Makefile.am
@@ -4,7 +4,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include \
 	      -I$(top_srcdir)/googletest/googletest/include \
 	      -I$(top_srcdir)/googletest/googletest \
 	      -std=c++11 \
-	      -Wno-write-strings
+	      -Wno-write-strings \
+	      -Wall
 LDADD = $(top_builddir)/src/.libs/libadaptived.la
 
 EXTRA_DIST = $(top_srcdir)/googletest/googletest/libgtest.so \


### PR DESCRIPTION
Enable -Wall for both functional and unit tests.  Also, in the github continuous integration, convert all warnings into errors.