### PR TITLE
adaptived: tests: cleanup test warnings to avoid rpmbuild warnings

### DIFF
--- a/adaptived/tests/ftests/010-snooze_effect.c
+++ b/adaptived/tests/ftests/010-snooze_effect.c
@@ -38,7 +38,6 @@ int main(int argc, char *argv[])
 	struct adaptived_rule_stats stats;
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
-	uint32_t trigger_cnt;
 	int ret;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/010-snooze_effect.json", argv[1]);

--- a/adaptived/tests/ftests/013-adaptived-asynchronous_loop.c
+++ b/adaptived/tests/ftests/013-adaptived-asynchronous_loop.c
@@ -52,7 +52,6 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	pthread_t adaptived_thread;
 	struct adaptived_ctx *ctx;
-	uint32_t loop_cnt;
 	double time_diff;
 	void *tret;
 	int ret;
@@ -122,7 +121,7 @@ int main(int argc, char *argv[])
 	if (ret)
 		goto err;
 	if (stats.loops_run_cnt != 3) {
-		adaptived_err("Expected 3 loops, but %d loops ran\n", loop_cnt);
+		adaptived_err("Expected 3 loops, but %d loops ran\n", stats.loops_run_cnt);
 		goto err;
 	}
 

--- a/adaptived/tests/ftests/015-load_rule_at_runtime.c
+++ b/adaptived/tests/ftests/015-load_rule_at_runtime.c
@@ -73,7 +73,7 @@ char *get_current_time(void)
 int main(int argc, char *argv[])
 {
 	struct adaptived_rule_stats stats;
-	uint32_t loop_cnt, rule_cnt;
+	uint32_t rule_cnt;
 	struct adaptived_effect *eff;
 	struct adaptived_cause *cse;
 	struct adaptived_rule *rule;

--- a/adaptived/tests/ftests/016-unload_rule_at_runtime.c
+++ b/adaptived/tests/ftests/016-unload_rule_at_runtime.c
@@ -73,7 +73,7 @@ char *get_current_time(void)
 int main(int argc, char *argv[])
 {
 	struct adaptived_rule_stats stats;
-	uint32_t loop_cnt, rule_cnt;
+	uint32_t rule_cnt;
 	struct adaptived_effect *eff;
 	struct adaptived_cause *cse;
 	struct adaptived_rule *rule;

--- a/adaptived/tests/ftests/025-effect-cgroup_setting_by_psi_1.c
+++ b/adaptived/tests/ftests/025-effect-cgroup_setting_by_psi_1.c
@@ -110,7 +110,6 @@ static int cgroup_files_contents[] = {
 	1000,
 	1000
 };
-static const int cgroup_files_contents_cnt = ARRAY_SIZE(cgroup_files_contents);
 static_assert(ARRAY_SIZE(cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "cgroup file contents array must be same length as cgroup files array");
 
@@ -123,7 +122,6 @@ static int expected_cgroup_files_contents[] = {
 	999,
 	1000
 };
-static const int expected_cgroup_files_contents_cnt = ARRAY_SIZE(expected_cgroup_files_contents);
 static_assert(ARRAY_SIZE(expected_cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "expected cgroup file contents array must be same length as cgroup files array");
 

--- a/adaptived/tests/ftests/026-effect-cgroup_setting_by_psi_2.c
+++ b/adaptived/tests/ftests/026-effect-cgroup_setting_by_psi_2.c
@@ -111,7 +111,6 @@ static int cgroup_files_contents[] = {
 	1000,
 	1000
 };
-static const int cgroup_files_contents_cnt = ARRAY_SIZE(cgroup_files_contents);
 static_assert(ARRAY_SIZE(cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "cgroup file contents array must be same length as cgroup files array");
 
@@ -124,7 +123,6 @@ static int expected_cgroup_files_contents[] = {
 	1000,
 	1003
 };
-static const int expected_cgroup_files_contents_cnt = ARRAY_SIZE(expected_cgroup_files_contents);
 static_assert(ARRAY_SIZE(expected_cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "expected cgroup file contents array must be same length as cgroup files array");
 

--- a/adaptived/tests/ftests/027-effect-cgroup_setting_by_psi_3.c
+++ b/adaptived/tests/ftests/027-effect-cgroup_setting_by_psi_3.c
@@ -104,7 +104,6 @@ static int cgroup_files_contents[] = {
 	100,
 	100
 };
-static const int cgroup_files_contents_cnt = ARRAY_SIZE(cgroup_files_contents);
 static_assert(ARRAY_SIZE(cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "cgroup file contents array must be same length as cgroup files array");
 
@@ -117,7 +116,6 @@ static int expected_cgroup_files_contents[] = {
 	100,
 	 75
 };
-static const int expected_cgroup_files_contents_cnt = ARRAY_SIZE(expected_cgroup_files_contents);
 static_assert(ARRAY_SIZE(expected_cgroup_files_contents) == ARRAY_SIZE(cgroup_files),
 	      "expected cgroup file contents array must be same length as cgroup files array");
 

--- a/adaptived/tests/ftests/045-effect-cgroup_memory_setting_add_int_max.c
+++ b/adaptived/tests/ftests/045-effect-cgroup_memory_setting_add_int_max.c
@@ -39,7 +39,6 @@
 #define EXPECTED_RET_FAIL 1
 
 static const char * const cgroup_file = "./test045.cgroup";
-static const long long expected_value = 25;
 
 int main(int argc, char *argv[])
 {

--- a/adaptived/tests/ftests/046-effect-cgroup_memory_setting_sub_int_max.c
+++ b/adaptived/tests/ftests/046-effect-cgroup_memory_setting_sub_int_max.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
-	int ret, fd, items;
+	int ret;
 	struct sysinfo info;
 	sysinfo(&info);
 	int br;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
 	memset(buf, 0, FILENAME_MAX);
 	strcpy(buf, line);
 	/* MemTotal:       527700340 kB */
-	items = sscanf(buf, "MemTotal:       %lld kB", &memtotal);
+	sscanf(buf, "MemTotal:       %lld kB", &memtotal);
 	memtotal *= 1024;
 
 	expected_value = memtotal - 1024;

--- a/adaptived/tests/ftests/061-cause-top_cpu_gt.c
+++ b/adaptived/tests/ftests/061-cause-top_cpu_gt.c
@@ -103,7 +103,6 @@ static int inject(struct adaptived_ctx * const ctx)
 	if (w <= 0)
 		ret = -errno;
 
-err:
 	close(fd);
 	ctr++;
 

--- a/adaptived/tests/ftests/062-cause-top_cpu_lt.c
+++ b/adaptived/tests/ftests/062-cause-top_cpu_lt.c
@@ -103,7 +103,6 @@ static int inject(struct adaptived_ctx * const ctx)
 	if (w <= 0)
 		ret = -errno;
 
-err:
 	close(fd);
 	ctr++;
 

--- a/adaptived/tests/ftests/063-cause-top_mem_gt.c
+++ b/adaptived/tests/ftests/063-cause-top_mem_gt.c
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
-	int ret;
+	int ret = -EINVAL;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/063-cause-top_mem_gt.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/064-cause-top_mem_lt.c
+++ b/adaptived/tests/ftests/064-cause-top_mem_lt.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
-	int ret;
+	int ret = -EINVAL;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/064-cause-top_mem_lt.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/066-cause-cgroup_memory_setting_ll_lt.c
+++ b/adaptived/tests/ftests/066-cause-cgroup_memory_setting_ll_lt.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
-	int ret, items, br;
+	int ret, br;
 	char buf[FILENAME_MAX];
 	long long memtotal, val;
 	FILE *fp;
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 	memset(buf, 0, FILENAME_MAX);
 	strcpy(buf, line);
 	/* MemTotal:       527700340 kB */
-	items = sscanf(buf, "MemTotal:       %lld kB", &memtotal);
+	sscanf(buf, "MemTotal:       %lld kB", &memtotal);
 	memtotal *= 1024;
 
 	val = strtol(maxbuf, 0, 0);

--- a/adaptived/tests/ftests/067-effect-kill_processes.c
+++ b/adaptived/tests/ftests/067-effect-kill_processes.c
@@ -147,10 +147,9 @@ int execute(int count)
 
 int wait_pids(int count, int expected_alive_count)
 {
-	int i, ret;
 	int alive_count = 0;
 	int killed_by_effect = 0;
-	pid_t killed[PID_COUNT] = { -1 };
+	int i;
 
 	for (i = 0; i < count; i++) {
 		if (pid[i] > 0) {
@@ -173,7 +172,6 @@ int wait_pids(int count, int expected_alive_count)
 			} while (ret == 0 && loops++ < ALIVE_TIME);
 			if (ret == 0) {
 				kill(pid[i], SIGKILL);
-				killed[i] = pid[i];
 				alive_count++;
 			}
 			adaptived_dbg("wait_pids: pid[%d]=%d, status=%d, ret=%d\n",
@@ -201,10 +199,8 @@ int wait_pids(int count, int expected_alive_count)
 int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
-	char cmdline[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
 	int ret;
-	int i;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/067-effect-kill_processes.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/068-effect-kill_processes_rss.c
+++ b/adaptived/tests/ftests/068-effect-kill_processes_rss.c
@@ -105,10 +105,9 @@ int execute(int count)
 
 int wait_pids(int count, int expected_alive_count)
 {
-	int i, ret;
+	int i;
 	int alive_count = 0;
 	int killed_by_effect = 0;
-	pid_t killed[PID_COUNT] = { -1 };
 
 	for (i = 0; i < count; i++) {
 		if (pid[i] > 0) {
@@ -131,7 +130,6 @@ int wait_pids(int count, int expected_alive_count)
 			} while (ret == 0 && loops++ < ALIVE_TIME);
 			if (ret == 0) {
 				kill(pid[i], SIGKILL);
-				killed[i] = pid[i];
 				alive_count++;
 			}
 			adaptived_dbg("wait_pids: pid[%d]=%d, status=%d, ret=%d\n",
@@ -159,10 +157,8 @@ int wait_pids(int count, int expected_alive_count)
 int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
-	char cmdline[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
 	int ret;
-	int i;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/068-effect-kill_processes_rss.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/069-effect-signal.c
+++ b/adaptived/tests/ftests/069-effect-signal.c
@@ -76,7 +76,7 @@ int execute(pid_t * const child_pid)
 {
 	char cmdline[FILENAME_MAX];
 	char *argv[2] = { NULL };
-	int i, ret = 0, fd;
+	int ret = 0, fd;
 
 	memset(cmdline, 0, FILENAME_MAX);
 
@@ -123,9 +123,8 @@ err:
 int main(int argc, char *argv[])
 {
 	char config_path[FILENAME_MAX];
-	char cmdline[FILENAME_MAX];
 	struct adaptived_ctx *ctx;
-	int ret, i, status;
+	int ret, status;
 	pid_t child_pid;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/069-effect-signal.json", argv[1]);

--- a/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
+++ b/adaptived/tests/ftests/1005-sudo-effect-sd_bus_setting_sub_infinity.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
 	char *cgrp_path = NULL, *cgrp_file = NULL;
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
-	int ret, items, version;
+	int ret, version;
         int br;
         char buf[FILENAME_MAX];
         long long memtotal;
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
         memset(buf, 0, FILENAME_MAX);
         strcpy(buf, line);
         /* MemTotal:       527700340 kB */
-        items = sscanf(buf, "MemTotal:       %lld kB", &memtotal);
+        sscanf(buf, "MemTotal:       %lld kB", &memtotal);
         memtotal *= 1024;
 
         expected_value = memtotal - 4096;

--- a/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.c
+++ b/adaptived/tests/ftests/1006-sudo-effect-sd_bus_setting_set_int_scope.c
@@ -48,8 +48,6 @@ int main(int argc, char *argv[])
 	char config_path[FILENAME_MAX];
 	struct adaptived_ctx *ctx = NULL;
 	int ret, version;
-	int i = 0;
-	int max_retries = 10;
 
 	snprintf(config_path, FILENAME_MAX - 1, "%s/1006-sudo-effect-sd_bus_setting_set_int_scope.json", argv[1]);
 	config_path[FILENAME_MAX - 1] = '\0';

--- a/adaptived/tests/ftests/ftests.c
+++ b/adaptived/tests/ftests/ftests.c
@@ -416,7 +416,6 @@ int stop_transient(const char *transient_name)
 		adaptived_dbg("stop_transient: %s, ret=%d\n", cmdline, ret);
 	}
 
-err:
 	if (cgrp_path)
 		free(cgrp_path);
 	return 0;
@@ -617,7 +616,7 @@ int start_unit(const char *unit_name, const char *cmd_to_run)
 	char cmdline[FILENAME_MAX];
 	char cmdbuf[FILENAME_MAX];
 	char *cgrp_path, *tmp_path;
-	int i, len;
+	int i = 0, len;
 	int max_retries = 10;
 	int ret;
 

--- a/adaptived/tests/gunit/001-adaptived_get_pressure.cpp
+++ b/adaptived/tests/gunit/001-adaptived_get_pressure.cpp
@@ -74,9 +74,9 @@ class AdaptivedGetPressureTest : public ::testing::Test {
 		ASSERT_GT(fd, 0);
 
 		ret = write(fd, SOME_LINE, strlen(SOME_LINE));
-		ASSERT_EQ(ret, strlen(SOME_LINE));
+		ASSERT_EQ(ret, (int)strlen(SOME_LINE));
 		ret = write(fd, FULL_LINE, strlen(FULL_LINE));
-		ASSERT_EQ(ret, strlen(FULL_LINE));
+		ASSERT_EQ(ret, (int)strlen(FULL_LINE));
 
 		close(fd);
 	}

--- a/adaptived/tests/gunit/002-adaptived_get_pressure_avg.cpp
+++ b/adaptived/tests/gunit/002-adaptived_get_pressure_avg.cpp
@@ -74,9 +74,9 @@ class AdaptivedGetPressureAvgTest : public ::testing::Test {
 		ASSERT_GT(fd, 0);
 
 		ret = write(fd, SOME_LINE, strlen(SOME_LINE));
-		ASSERT_EQ(ret, strlen(SOME_LINE));
+		ASSERT_EQ(ret, (int)strlen(SOME_LINE));
 		ret = write(fd, FULL_LINE, strlen(FULL_LINE));
-		ASSERT_EQ(ret, strlen(FULL_LINE));
+		ASSERT_EQ(ret, (int)strlen(FULL_LINE));
 
 		close(fd);
 	}

--- a/adaptived/tests/gunit/004-adaptived_farray_linear_regression.cpp
+++ b/adaptived/tests/gunit/004-adaptived_farray_linear_regression.cpp
@@ -40,7 +40,7 @@ TEST_F(FarrayLinearRegressionTest, IntervalOfOne)
 	float y[] = {94.6, 88.4, 92.5, 90.1, 84.3, 75.7, 75.9, 80.2, 65.8, 60.9, 62.3,
 		     58.9, 58.5, 63.5, 55.4, 59.4, 56.3, 52.1, 51.1, 48.6, 47.9, 51.8,
 		     50.3, 45.6, 43.2, 43.1, 46.2, 40.7, 38.9, 37.5, 35.9, 40.2, 38.7};
-	int interval, y_len, ret;
+	int y_len, ret;
 	float interp_y;
 
 	y_len = ARRAY_SIZE(y);
@@ -61,7 +61,7 @@ TEST_F(FarrayLinearRegressionTest, IntervalOfOne)
 TEST_F(FarrayLinearRegressionTest, IntervalOfTwo)
 {
 	float y[] = {7.0, 8.0, 6.0, 10.0, 15.0, 12.0, 14.0, 17.0, 21.0, 26.0, 29.0};
-	int interval, y_len, ret;
+	int y_len, ret;
 	float interp_y;
 
 	y_len = ARRAY_SIZE(y);

--- a/adaptived/tests/gunit/007-path_walk.cpp
+++ b/adaptived/tests/gunit/007-path_walk.cpp
@@ -74,12 +74,12 @@ class PathWalkTest : public ::testing::Test {
 		int ret, i;
 		FILE *f;
 
-		for (i = 0; i < ARRAY_SIZE(dirs); i++) {
+		for (i = 0; i < (int)ARRAY_SIZE(dirs); i++) {
 			ret = mkdir(dirs[i], S_IRWXU | S_IRWXG | S_IRWXO);
 			ASSERT_EQ(ret, 0);
 		}
 
-		for (i = 0; i < ARRAY_SIZE(files); i++) {
+		for (i = 0; i < (int)ARRAY_SIZE(files); i++) {
 			f = fopen(files[i], "w");
 			ASSERT_NE(f, nullptr);
 			fclose(f);
@@ -111,7 +111,7 @@ static int get_dir_index(const char * const path)
 {
 	int i;
 
-	for (i = 0; i < ARRAY_SIZE(dirs); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++) {
 		if (strcmp(path, dirs[i]) == 0)
 			return i;
 	}
@@ -123,7 +123,7 @@ static int get_file_index(const char * const path)
 {
 	int i;
 
-	for (i = 0; i < ARRAY_SIZE(files); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++) {
 		if (strcmp(path, files[i]) == 0)
 			return i;
 	}
@@ -205,7 +205,7 @@ TEST_F(PathWalkTest, WalkDirectories)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(dirs); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++)
 		ASSERT_TRUE(found[i]);
 }
 
@@ -237,7 +237,7 @@ TEST_F(PathWalkTest, WalkFiles)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(files); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++)
 		ASSERT_TRUE(found[i]);
 }
 
@@ -275,16 +275,16 @@ TEST_F(PathWalkTest, WalkFilesAndDirs)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(files); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++)
 		ASSERT_TRUE(found_f[i]);
-	for (i = 0; i < ARRAY_SIZE(dirs); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++)
 		ASSERT_TRUE(found_d[i]);
 }
 
 TEST_F(PathWalkTest, WalkFilesAndDirsNoRecurse)
 {
 	struct adaptived_path_walk_handle *handle = NULL;
-	int ret, index, i = 0;
+	int ret, i = 0;
 	char *next = NULL;
 
 	ret = adaptived_path_walk_start(dirs[0], &handle,
@@ -306,9 +306,10 @@ TEST_F(PathWalkTest, WalkFilesAndDirsNoRecurse)
 			    strcmp(next, "test007/cgroup.procs") != 0 &&
 			    strcmp(next, "test007/child1") != 0 &&
 			    strcmp(next, "test007/child2") != 0 &&
-			    strcmp(next, "test007/child3") != 0)
+			    strcmp(next, "test007/child3") != 0) {
 				/* An unexpected string matched.  Always fail */
 				ASSERT_STREQ(next, nullptr);
+			}
 		}
 	} while (ret == 0 && next);
 
@@ -392,11 +393,11 @@ TEST_F(PathWalkTest, WalkFilesAndDirsWildcard)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(files); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++)
 		ASSERT_TRUE(found_f[i]);
 
 	ASSERT_FALSE(found_d[0]);
-	for (i = 1; i < ARRAY_SIZE(dirs); i++)
+	for (i = 1; i < (int)ARRAY_SIZE(dirs); i++)
 		ASSERT_TRUE(found_d[i]);
 }
 
@@ -434,9 +435,9 @@ TEST_F(PathWalkTest, WalkFilesAndDirsWildcard2)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(files); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++)
 		ASSERT_TRUE(found_f[i]);
-	for (i = 0; i < ARRAY_SIZE(dirs); i++)
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++)
 		ASSERT_TRUE(found_d[i]);
 }
 
@@ -467,7 +468,7 @@ static void walk_directories_test(int max_depth)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(dirs); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++) {
 		depth = get_depth(dirs[i]);
 		if (depth <= max_depth)
 			ASSERT_TRUE(found[i]);
@@ -530,14 +531,14 @@ static void walk_dirs_and_files_test(int max_depth)
 	adaptived_path_walk_end(&handle);
 	ASSERT_EQ(handle, nullptr);
 
-	for (i = 0; i < ARRAY_SIZE(files); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(files); i++) {
 		depth = get_depth(files[i]);
 		if (depth <= max_depth)
 			ASSERT_TRUE(found_f[i]);
 		else
 			ASSERT_FALSE(found_f[i]);
 	}
-	for (i = 0; i < ARRAY_SIZE(dirs); i++) {
+	for (i = 0; i < (int)ARRAY_SIZE(dirs); i++) {
 		depth = get_depth(dirs[i]);
 		if (depth <= max_depth)
 			ASSERT_TRUE(found_d[i]);

--- a/adaptived/tests/gunit/008-cgroup_get_procs.cpp
+++ b/adaptived/tests/gunit/008-cgroup_get_procs.cpp
@@ -61,15 +61,14 @@ class CgroupGetProcsTest : public ::testing::Test {
 
 		for (i = 0; i < pids_cnt; i++) {
 			written = fprintf(f, "%d\n", pids[i]);
-			ASSERT_GE(written, 1);
+			ASSERT_GE(written, (size_t)1);
 		}
 
 		fclose(f);
 	}
 
 	void SetUp() override {
-		int ret, i;
-		FILE *f;
+		int ret;
 
 		ret = mkdir(cgroup_path_1, S_IRWXU | S_IRWXG | S_IRWXO);
 		ASSERT_EQ(ret, 0);

--- a/adaptived/tests/gunit/010-adaptived_get_schedstats.cpp
+++ b/adaptived/tests/gunit/010-adaptived_get_schedstats.cpp
@@ -101,44 +101,44 @@ TEST_F(GetSchedstatsTest, GetSnapshot)
 	ASSERT_EQ(ss.nr_cpus, 4);
 	ASSERT_EQ(ss.timestamp, 5979263307LU);
 
-	ASSERT_EQ(ss.schedstat_cpus[0].ttwu, 0);
-	ASSERT_EQ(ss.schedstat_cpus[0].ttwu_local, 0);
+	ASSERT_EQ(ss.schedstat_cpus[0].ttwu, 0U);
+	ASSERT_EQ(ss.schedstat_cpus[0].ttwu_local, 0U);
 	ASSERT_EQ(ss.schedstat_cpus[0].run_time, 43076095314418LLU);
 	ASSERT_EQ(ss.schedstat_cpus[0].run_delay, 394914672557LLU);
 	ASSERT_EQ(ss.schedstat_cpus[0].nr_timeslices, 428184882LU);
-	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[0].ttwu_remote, 1);
-	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[0].ttwu_move_affine, 2);
-	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[1].ttwu_remote, 3);
-	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[1].ttwu_move_affine, 4);
+	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[0].ttwu_remote, 1U);
+	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[0].ttwu_move_affine, 2U);
+	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[1].ttwu_remote, 3U);
+	ASSERT_EQ(ss.schedstat_cpus[0].schedstat_domains[1].ttwu_move_affine, 4U);
 
 
-	ASSERT_EQ(ss.schedstat_cpus[1].ttwu, 0);
-	ASSERT_EQ(ss.schedstat_cpus[1].ttwu_local, 0);
+	ASSERT_EQ(ss.schedstat_cpus[1].ttwu, 0U);
+	ASSERT_EQ(ss.schedstat_cpus[1].ttwu_local, 0U);
 	ASSERT_EQ(ss.schedstat_cpus[1].run_time, 10913795519351LLU);
 	ASSERT_EQ(ss.schedstat_cpus[1].run_delay, 136791545255LLU);
 	ASSERT_EQ(ss.schedstat_cpus[1].nr_timeslices, 100532045LU);
-	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[0].ttwu_remote, 5);
-	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[0].ttwu_move_affine, 6);
-	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[1].ttwu_remote, 7);
-	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[1].ttwu_move_affine, 8);
+	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[0].ttwu_remote, 5U);
+	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[0].ttwu_move_affine, 6U);
+	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[1].ttwu_remote, 7U);
+	ASSERT_EQ(ss.schedstat_cpus[1].schedstat_domains[1].ttwu_move_affine, 8U);
 
-	ASSERT_EQ(ss.schedstat_cpus[2].ttwu, 0);
-	ASSERT_EQ(ss.schedstat_cpus[2].ttwu_local, 0);
+	ASSERT_EQ(ss.schedstat_cpus[2].ttwu, 0U);
+	ASSERT_EQ(ss.schedstat_cpus[2].ttwu_local, 0U);
 	ASSERT_EQ(ss.schedstat_cpus[2].run_time, 54048015265649LLU);
 	ASSERT_EQ(ss.schedstat_cpus[2].run_delay, 599770051010LLU);
 	ASSERT_EQ(ss.schedstat_cpus[2].nr_timeslices, 527416276LU);
-	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[0].ttwu_remote, 9);
-	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[0].ttwu_move_affine, 10);
-	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[1].ttwu_remote, 11);
-	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[1].ttwu_move_affine, 12);
+	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[0].ttwu_remote, 9U);
+	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[0].ttwu_move_affine, 10U);
+	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[1].ttwu_remote, 11U);
+	ASSERT_EQ(ss.schedstat_cpus[2].schedstat_domains[1].ttwu_move_affine, 12U);
 
-	ASSERT_EQ(ss.schedstat_cpus[3].ttwu, 0);
-	ASSERT_EQ(ss.schedstat_cpus[3].ttwu_local, 0);
+	ASSERT_EQ(ss.schedstat_cpus[3].ttwu, 0U);
+	ASSERT_EQ(ss.schedstat_cpus[3].ttwu_local, 0U);
 	ASSERT_EQ(ss.schedstat_cpus[3].run_time, 9043880713438LLU);
 	ASSERT_EQ(ss.schedstat_cpus[3].run_delay, 172082515008LLU);
 	ASSERT_EQ(ss.schedstat_cpus[3].nr_timeslices, 83848679LU);
-	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[0].ttwu_remote, 13);
-	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[0].ttwu_move_affine, 14);
-	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[1].ttwu_remote, 15);
-	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[1].ttwu_move_affine, 16);
+	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[0].ttwu_remote, 13U);
+	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[0].ttwu_move_affine, 14U);
+	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[1].ttwu_remote, 15U);
+	ASSERT_EQ(ss.schedstat_cpus[3].schedstat_domains[1].ttwu_move_affine, 16U);
 }

--- a/adaptived/tests/gunit/011-kill_processes_sort.cpp
+++ b/adaptived/tests/gunit/011-kill_processes_sort.cpp
@@ -57,7 +57,7 @@ class SortPidListTest : public ::testing::Test {
 	protected:
 
 	void SetUp() override {
-		ASSERT_EQ(array_size, ARRAY_SIZE(vsizes));
+		ASSERT_EQ(array_size, (int)ARRAY_SIZE(vsizes));
 	}
 };
 


### PR DESCRIPTION
Cleanup warnings in tests/ftests and  tests/gunit to avoid rpmbuild warnings.

This is a pull request based on https://github.com/oracle/adaptivemm/pull/30 with the requisite acked-by's and signed-off-by's added.