### PR TITLE
adaptived: Fix a memory leak reported by Coverity

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,12 +142,6 @@ jobs:
       run: |
         cat adaptived/tests/ftests/ftests-wrapper.sh.log
         cat adaptived/tests/ftests/ftests-c-wrapper.sh.log
-    - name: Archive test logs
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Adaptived functional test logs
-        path: adaptived/tests/*/*.log
     - name: Collate code coverage results
       uses: ./.github/actions/code-coverage
     - name: Upload code coverage results
@@ -155,14 +149,8 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./lcov.total
-        flag-name: "Adaptived Functional Tests"
+        flag-name: "Adaptived Functional Tests - cgv1"
         parallel: True
-    - name: Archive code coverage results
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Adaptived Functional Tests Code Coverage
-        path: lcov.*
 
   functional_tests_cgv2:
     name: Adaptived Functional Tests v2
@@ -185,12 +173,6 @@ jobs:
       run: |
         cat adaptived/tests/ftests/ftests-wrapper.sh.log
         cat adaptived/tests/ftests/ftests-c-wrapper.sh.log
-    - name: Archive test logs
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Adaptived functional test logs
-        path: adaptived/tests/*/*.log
     - name: Collate code coverage results
       uses: ./.github/actions/code-coverage
     - name: Upload code coverage results
@@ -198,14 +180,8 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./lcov.total
-        flag-name: "Adaptived Functional Tests"
+        flag-name: "Adaptived Functional Tests - cgv2"
         parallel: True
-    - name: Archive code coverage results
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: Adaptived Functional Tests Code Coverage
-        path: lcov.*
 
   finalize:
     name: Finalize the test run

--- a/adaptived/src/effects/cgroup_setting_by_psi.c
+++ b/adaptived/src/effects/cgroup_setting_by_psi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates.
+ * Copyright (c) 2024-2025, Oracle and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,6 +205,8 @@ error:
 	if (opts) {
 		if (opts->cgroup_path)
 			free(opts->cgroup_path);
+		if (opts->cgroup_setting)
+			free(opts->cgroup_setting);
 		adaptived_free_cgroup_value(&opts->value);
 		adaptived_free_cgroup_value(&opts->limit);
 
@@ -461,6 +463,8 @@ void cgroup_setting_psi_exit(struct adaptived_effect * const eff)
 
 	if (opts->cgroup_path)
 		free(opts->cgroup_path);
+	if (opts->cgroup_setting)
+		free(opts->cgroup_setting);
 	adaptived_free_cgroup_value(&opts->value);
 	adaptived_free_cgroup_value(&opts->limit);
 	free(opts);


### PR DESCRIPTION
Fix the following coverity warning in the cgroup_setting_by_psi effect:
    
            The system resource will not be reclaimed and reused, reducing
            the future availability of the resource.
    
            In cgroup_setting_psi_init: Leak of memory or pointers to system
            resources (CWE-404)