### PR TITLE
adaptived: effects: Fix coverity warning in cgroup_setting_psi_init()

### DIFF
--- a/adaptived/src/effects/cgroup_setting_by_psi.c
+++ b/adaptived/src/effects/cgroup_setting_by_psi.c
@@ -72,6 +72,7 @@ int cgroup_setting_psi_init(struct adaptived_effect * const eff, struct json_obj
 		goto error;
 	}
 	opts->cgroup_path = NULL;
+	opts->cgroup_setting = NULL;
 	opts->value.type = ADAPTIVED_CGVAL_CNT;
 	opts->limit.type = ADAPTIVED_CGVAL_CNT;
 	opts->limit_provided = false;


### PR DESCRIPTION
Fix uninitialized pointer read Coverity warning in cgroup_setting_psi_init():

	Incorrect values could be read from, or even written to, an
	arbitrary memory location, causing incorrect computations.

	In cgroup_setting_psi_init: Reads an uninitialized pointer or
	its target (CWE-457)